### PR TITLE
fix: add optional string type to theme

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -35,7 +35,7 @@ export interface EditorProps {
   /**
    * Default themes of monaco. Defaults to "light"
    */
-  theme?: Theme;
+  theme?: Theme | string;
 
   /**
    * The line to jump on it


### PR DESCRIPTION
This PR fixes the editor types NOT accepting anything but `dark` or `light`. This adds a union type to allow users to pass anything but also keeps autocomplete for light/dark.